### PR TITLE
Fix typos

### DIFF
--- a/config/surrogate/metanpt.yaml
+++ b/config/surrogate/metanpt.yaml
@@ -4,7 +4,7 @@ train_config:
   support_size: 0 # 0 # 16 # 128 # null
   query_size: 100 # 100
   use_all_data: False
-  max_context_sz: 228 # 100 # 116 # 228 # 1000 # Limits max contex if support or query set varies (is null)
+  max_context_sz: 228 # 100 # 116 # 228 # 1000 # Limits max context if support or query set varies (is null)
   default_query_sz: 100 # Only used in evaluation and if query_sz is null
   default_support_sz: 128 # Only used in evaluation and if query_sz is null
   num_train_steps: 50000 # 25000 # 50000 # 100000

--- a/meta/io.py
+++ b/meta/io.py
@@ -53,9 +53,9 @@ class FileHandler:
         self.s3_endpoint = s3_endpoint
         self.bucket = bucket
         # Assert that bucket is in {"input", "output"}. This could change along with
-        # Ichor's infrastructure but is for now structured as an input and ouput
+        # Ichor's infrastructure but is for now structured as an input and output
         # bucket.
-        # WARNING: if "bucket" == "ouput", the files will be stored under a folder
+        # WARNING: if "bucket" == "output", the files will be stored under a folder
         # named after the experiment whereas saving in the "input" bucket is more
         # straightforward as the path is directly used.
 

--- a/meta/models/base_metasurrogate.py
+++ b/meta/models/base_metasurrogate.py
@@ -83,7 +83,7 @@ class BaseMetaSurrogate(abc.ABC):
         num_steps: Optional[int] = None,
     ) -> None:
         """
-        Train surrogate model on multiple datsets of labelled candidates.
+        Train surrogate model on multiple datasets of labelled candidates.
         n.b. Pass train_data to generate_support_query_splits() to generate
         data for training.
         """
@@ -159,7 +159,7 @@ class BaseMetaSurrogate(abc.ABC):
         num_evals: Optional[int],
         normalization: Optional[str],
     ) -> Generator[Tuple[OraclePoints, OraclePoints, str, None], None, None]:
-        """Generate multiple splits of each tast for training and evaluation.
+        """Generate multiple splits of each task for training and evaluation.
 
         Split the data into support sets (context) and query sets (targets).
         Also returns the task name from which the batch was sampled.
@@ -193,7 +193,7 @@ class BaseMetaSurrogate(abc.ABC):
                         permuted_data[split:],
                     )
                 elif self.support_size is None:
-                    # Select suport set size
+                    # Select support set size
                     max_support_size = len(permuted_data) - self.query_size  # type: ignore
                     cur_support_size = (
                         max_support_size

--- a/meta/models/metasurrogate.py
+++ b/meta/models/metasurrogate.py
@@ -393,7 +393,7 @@ class ProteinNPTMetaSurrogate(BaseMetaSurrogate, nn.Module):
         # Dropout and norm layers
         self.dropout_module = nn.Dropout(self.dropout_prob)
         # Note these layer norms were originally ESM1bLayerNorm layers
-        # But, I beleive they were being imported as untrained LayerNorm anyway?
+        # But, I believe they were being imported as untrained LayerNorm anyway?
         self.emb_layer_norm_before = nn.LayerNorm(self.embed_dim)
         self.emb_layer_norm_after = nn.LayerNorm(self.embed_dim)
 
@@ -535,7 +535,7 @@ class ProteinNPTMetaSurrogate(BaseMetaSurrogate, nn.Module):
                 # Skip if this task if there is not enough data
                 continue
             attention = attention.squeeze(3)
-            # Average over lenth of protein sequence
+            # Average over length of protein sequence
             attention = torch.mean(attention, dim=2)
             expected_shape = (
                 self.num_protein_npt_layers,
@@ -718,7 +718,7 @@ class ProteinNPTMetaSurrogate(BaseMetaSurrogate, nn.Module):
         # Divide the support and query sets in half to avoid overlap
         self.support_size = len(support_set) // 2
         self.query_size = len(query_set) // 2
-        # Limit the query size to half the support size since we cant use more data than in support
+        # Limit the query size to half the support size since we can't use more data than in support
         self.query_size = min(self.query_size, len(support_set) // 2)
 
         # Fit the model on the support set
@@ -747,7 +747,7 @@ class ProteinNPTMetaSurrogate(BaseMetaSurrogate, nn.Module):
                     assert len(
                         query_set <= eval_query_size
                     ), "Query set too large; chunking not implemented for split support."
-                    # Split the support ans query in half and make predictions on each half
+                    # Split the support and query in half and make predictions on each half
                     support1 = support_set[: self.support_size // 2]
                     query1 = query_set[: self.query_size // 2]
                     preds1, _, _, _, _ = self.embed_and_forward(
@@ -760,7 +760,7 @@ class ProteinNPTMetaSurrogate(BaseMetaSurrogate, nn.Module):
                     )
                     preds = torch.cat([preds1, preds2], dim=0)
                 elif self.train_config.finetune_eval_chunk_strategy == "full":
-                    # Assume that the support is not split and query can be arbtirarily large
+                    # Assume that the support is not split and query can be arbitrarily large
                     preds, _, _, _, _ = self.embed_and_forward(
                         support_set, query_set, task_name, False
                     )
@@ -1002,7 +1002,7 @@ class ProteinNPTMetaSurrogate(BaseMetaSurrogate, nn.Module):
                 self.embed_dim,
             ), f"Found shape {aux_y.shape}"
 
-        # Concatentate x and y
+        # Concatenate x and y
         x = torch.cat((x, y), dim=-2)  # 1, N, (L+1), D
         if aux_y is not None:  # 1, N, (L+2), D
             x = torch.cat((x, aux_y), dim=-2)
@@ -1177,7 +1177,7 @@ class ProteinNPTMetaSurrogate(BaseMetaSurrogate, nn.Module):
                 mean_theta = torch.mean(
                     torch.stack([p[param_num] for p in task_thetas]), dim=0
                 )
-                # Note: The lerning rate used in the inner-loop skips the warmup phase
+                # Note: The learning rate used in the inner-loop skips the warmup phase
                 #       and only runs for 100 updates max, so it is apprximately
                 #       self.train_config.learning_rate the whole time
                 # Set the gradient
@@ -1221,7 +1221,7 @@ class ProteinNPTMetaSurrogate(BaseMetaSurrogate, nn.Module):
         finetuning: bool = False,
     ) -> None:
         """
-        Train metasurrogate model on multiple datsets of labelled candidates.
+        Train metasurrogate model on multiple datasets of labelled candidates.
         Uses generate_support_query_splits() in BaseMetaSurrogate to generate
         data for training.
         """
@@ -1473,7 +1473,7 @@ class ProteinNPTMetaSurrogate(BaseMetaSurrogate, nn.Module):
             log.info(f"Batch Time elapsed: {(time.time() - batch_start_t):.2f} seconds")
             log.info(f"Total Time elapsed: {int(time.time() - t0)} seconds")
             time_remaining = (time.time() - t0) / step * (num_steps - step)
-            log.info(f"Avgerage Batch Time: {((time.time() - t0) / step):.2f} seconds")
+            log.info(f"Average Batch Time: {((time.time() - t0) / step):.2f} seconds")
             log.info(f"Estimated time remaining: {int(time_remaining)} seconds")
 
             # gc.collect()

--- a/meta/npt/proteinnpt/proteinnpt/data_processing.py
+++ b/meta/npt/proteinnpt/proteinnpt/data_processing.py
@@ -335,7 +335,7 @@ def process_batch(
         batch["mutant_mutated_seq_pairs"] += model.MSA_sample_sequences
 
     # Slice sequences around mutation if sequence longer than context length
-    # (consistenly with what has happened in embeddings.py)
+    # (consistently with what has happened in embeddings.py)
     if (
         args.max_positions is not None and raw_sequence_length + 1 > args.max_positions
     ):  # Adding one for the BOS token

--- a/meta/npt/proteinnpt/utils/esm/data.py
+++ b/meta/npt/proteinnpt/utils/esm/data.py
@@ -413,7 +413,7 @@ class ESMStructuralSplitDataset(torch.utils.data.Dataset):
     we have split the data into 5 partitions for cross validation. These are provided
     in a downloaded splits folder, in the format:
             splits/{split_level}/{cv_partition}/{train|valid}.txt
-    where train is the partition and valid is the concatentation of the remaining 4.
+    where train is the partition and valid is the concatenation of the remaining 4.
 
     For each SCOPe domain, we provide a pkl dump that contains:
         - seq    : The domain sequence, stored as an L-length string
@@ -495,7 +495,7 @@ class ESMStructuralSplitDataset(torch.utils.data.Dataset):
 
     def __getitem__(self, idx):
         """
-        Returns a dict with the following entires
+        Returns a dict with the following entries
          - seq : Str (domain sequence)
          - ssp : Str (SSP labels)
          - dist : np.array (distance map)

--- a/meta/npt/proteinnpt/utils/model_utils.py
+++ b/meta/npt/proteinnpt/utils/model_utils.py
@@ -151,7 +151,7 @@ class Trainer:
 
     def train(self):
         """
-        Returns the last value of training_step (useful in case of early stopping for isntance)
+        Returns the last value of training_step (useful in case of early stopping for instance)
         """
 
         self.model.train()

--- a/meta/npt/proteinnpt/utils/msa_utils.py
+++ b/meta/npt/proteinnpt/utils/msa_utils.py
@@ -381,7 +381,7 @@ def weighted_sample_MSA(
     MSA_all_sequences, MSA_non_ref_sequences_weights, number_sampled_MSA_sequences
 ):
     """
-    We always enforce the first sequence in the MSA to be the refence sequence.
+    We always enforce the first sequence in the MSA to be the reference sequence.
     """
     msa = [MSA_all_sequences[0]]
     msa.extend(

--- a/meta/npt/proteinnpt/utils/tranception/utils/scoring_utils.py
+++ b/meta/npt/proteinnpt/utils/tranception/utils/scoring_utils.py
@@ -103,7 +103,7 @@ def sequence_replace_single(sequence, char_to_replace, char_replacements):
 
 def sequence_replace(sequences, char_to_replace, char_replacements):
     """
-    Helper function that replaces all Amino Acids passsed in via char_to_replace (as a string of AAs) with Amino Acids sampled from char_replacements (also a string of eligible AAs).
+    Helper function that replaces all Amino Acids passed in via char_to_replace (as a string of AAs) with Amino Acids sampled from char_replacements (also a string of eligible AAs).
     """
     return [
         sequence_replace_single(sequence, char_to_replace, char_replacements)

--- a/meta/tasks/proteingym/tasks.py
+++ b/meta/tasks/proteingym/tasks.py
@@ -397,7 +397,7 @@ class ProteinGymMetaSLTask:  # Cannot implement SupervisedTask since the return 
         # Iterate over val data in different ways
         for gen_name, num_evals in generators_and_evals:
 
-            # Iterate over numver of evaluations
+            # Iterate over number of evaluations
             for _ in range(num_evals):
 
                 # Store the metrics for each task in a list

--- a/meta/tasks/utils.py
+++ b/meta/tasks/utils.py
@@ -88,7 +88,7 @@ def oracle_points_to_dataframe(
 
 
 def oracle_points_to_hf_dataset(oracle_points: OraclePoints) -> Dataset:
-    """Conver OraclePoints to HF Dataset."""
+    """Convert OraclePoints to HF Dataset."""
     raise NotImplementedError()
 
 

--- a/run_metasupervised.py
+++ b/run_metasupervised.py
@@ -42,7 +42,7 @@ def run_metasupervised(cfg: DictConfig) -> None:  # noqa: CCR001
     set_seeds(cfg.seed)
     task = hydra.utils.instantiate(cfg.task)
     log.info("Setting up task (splitting datasets etc.)")
-    # load 0-shot data if using auxillary zero-shot predictions
+    # load 0-shot data if using auxiliary zero-shot predictions
     load_zero_shot =  cfg.surrogate.model_config.aux_pred
     task.setup_datasets(load_zero_shot=load_zero_shot)
     commit_hash = get_current_git_commit_hash()


### PR DESCRIPTION
This PR fixes a few typos by running [`codespell`](https://github.com/codespell-project/codespell) on the repository.

```
$ codespell . -L metalic,aas,otu,pastin,notin --skip="*.csv"
./run_metasupervised.py:45: auxillary ==> auxiliary
./meta/io.py:56: ouput ==> output
./meta/io.py:58: ouput ==> output
./meta/tasks/utils.py:91: Conver ==> Convert, Cover, Convex, Convey, Confer
./meta/tasks/proteingym/tasks.py:400: numver ==> number
./meta/npt/proteinnpt/proteinnpt/data_processing.py:338: consistenly ==> consistently
./meta/npt/proteinnpt/utils/model_utils.py:154: isntance ==> instance
./meta/npt/proteinnpt/utils/msa_utils.py:384: refence ==> reference
./meta/npt/proteinnpt/utils/esm/data.py:416: concatentation ==> concatenation
./meta/npt/proteinnpt/utils/esm/data.py:498: entires ==> entries
./meta/npt/proteinnpt/utils/tranception/utils/scoring_utils.py:106: passsed ==> passed
./meta/models/base_metasurrogate.py:86: datsets ==> datasets
./meta/models/base_metasurrogate.py:162: tast ==> taste, test, task
./meta/models/base_metasurrogate.py:196: suport ==> support
./meta/models/metasurrogate.py:396: beleive ==> believe
./meta/models/metasurrogate.py:538: lenth ==> length
./meta/models/metasurrogate.py:721: cant ==> can't
./meta/models/metasurrogate.py:750: ans ==> and
./meta/models/metasurrogate.py:763: arbtirarily ==> arbitrarily
./meta/models/metasurrogate.py:1005: Concatentate ==> Concatenate
./meta/models/metasurrogate.py:1180: lerning ==> learning, leaning
./meta/models/metasurrogate.py:1224: datsets ==> datasets
./meta/models/metasurrogate.py:1476: Avgerage ==> Average
./config/surrogate/metanpt.yaml:7: contex ==> context
```

Note that your `pyproject.toml` fails to be parsed by `codespell`, so I temporarily renamed it for the above command to work. 

```
$ codespell . -L metalic,aas,otu,pastin,notin --skip="*.csv"
Traceback (most recent call last):
  File "/home/j-vangoey/.local/bin/codespell", line 8, in <module>
    sys.exit(_script_main())
             ^^^^^^^^^^^^^^
  File "/home/j-vangoey/.local/share/uv/tools/codespell/lib/python3.11/site-packages/codespell_lib/_codespell.py", line 1121, in _script_main
    return main(*sys.argv[1:])
           ^^^^^^^^^^^^^^^^^^^
  File "/home/j-vangoey/.local/share/uv/tools/codespell/lib/python3.11/site-packages/codespell_lib/_codespell.py", line 1127, in main
    options, parser, used_cfg_files = parse_options(args)
                                      ^^^^^^^^^^^^^^^^^^^
  File "/home/j-vangoey/.local/share/uv/tools/codespell/lib/python3.11/site-packages/codespell_lib/_codespell.py", line 628, in parse_options
    data = tomllib.load(f).get("tool", {})
           ^^^^^^^^^^^^^^^
  File "/home/j-vangoey/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/tomllib/_parser.py", line 66, in load
    return loads(s, parse_float=parse_float)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/j-vangoey/.local/share/uv/python/cpython-3.11.9-linux-x86_64-gnu/lib/python3.11/tomllib/_parser.py", line 127, in loads
    raise suffixed_err(
tomllib.TOMLDecodeError: Expected newline or end of document after a statement (at line 5, column 22)
```